### PR TITLE
fix: send model_id to call upload_predictions

### DIFF
--- a/numerai_compute/examples/python3/predict.py
+++ b/numerai_compute/examples/python3/predict.py
@@ -82,7 +82,7 @@ def submit(predictions, model_id=None):
     # Numerai API uses Environment variables to find your keys: NUMERAI_PUBLIC_ID and NUMERAI_SECRET_KEY
     # these are set by docker via the numerai cli; see README for more info
     logging.info(f'submitting')
-    napi.upload_predictions(predict_output_path, model_id)
+    napi.upload_predictions(predict_output_path, model_id=model_id)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`napi.upload_predictions(predict_output_path, model_id)`
makes fail the example script the current napi implementation look like

```
    def upload_predictions(self, file_path: str, tournament: int = 8,
                           model_id: str = None) -> str:
```

