### PR TITLE
Update .dockerignore to ignore numerai dataset zip

### DIFF
--- a/numerai_compute/cli.py
+++ b/numerai_compute/cli.py
@@ -490,7 +490,7 @@ def copy_example(quiet, force, rlang, signals):
 
     with open('.dockerignore', 'a+') as f:
         f.write(".numerai\n")
-        f.write("numerai_dataset.zip\n")
+        f.write("numerai_dataset_*.zip\n")
         f.write(".git\n")
 
 


### PR DESCRIPTION
The name of the numerai dataset zip archive contains the round number (e.g. `numerai_dataset_255.zip`)
Minor change to ignore independent of the round