### PR TITLE
Handling missing provider keys

### DIFF
--- a/numerai/cli/uninstall.py
+++ b/numerai/cli/uninstall.py
@@ -41,7 +41,8 @@ def uninstall():
         all_keys = load_or_init_keys()
         provider_keys = {}
         for provider in PROVIDERS:
-            provider_keys.update(all_keys[provider])
+            if provider in all_keys.keys():
+                provider_keys.update(all_keys[provider])
         terraform('destroy -auto-approve',
                   verbose=True, env_vars=provider_keys,
                   inputs={'node_config_file': 'nodes.json'})

--- a/numerai/cli/util/keys.py
+++ b/numerai/cli/util/keys.py
@@ -155,9 +155,10 @@ def sanitize_message(message):
         return None
     all_keys = get_aws_keys() + get_numerai_keys()
     for key in all_keys:
-        try:
-            message = message.replace(key, f'...{key[-5:]}')
-        except AttributeError:
-            continue
+        if key:
+            try:
+                message = message.replace(key, f'...{key[-5:]}')
+            except AttributeError:
+                continue
 
     return message


### PR DESCRIPTION
Still fails on `terraform('destroy -auto-approve', verbose=True, env_vars=provider_keys, inputs={'node_config_file': 'nodes.json'})`