### PR TITLE
examples: adding `no-cache-dir` option to pip install

### DIFF
--- a/numerai/examples/signals-python3/Dockerfile
+++ b/numerai/examples/signals-python3/Dockerfile
@@ -23,7 +23,7 @@ ENV SRC_PATH=$SRC_PATH
 # The `ADD [source] [destination]` command will take a file from the source directory on your computer
 # and copy it over to the destination directory in the Docker container.
 ADD $SRC_PATH/requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --no-cache-dir
 
 # Now, add everything in the source code directory.
 # (including your code, compiled files, serialized models, everything...)

--- a/numerai/examples/tournament-python3/Dockerfile
+++ b/numerai/examples/tournament-python3/Dockerfile
@@ -23,7 +23,7 @@ ENV SRC_PATH=$SRC_PATH
 # The `ADD [source] [destination]` command will take a file from the source directory on your computer
 # and copy it over to the destination directory in the Docker container.
 ADD $SRC_PATH/requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --no-cache-dir
 
 # Now, add everything in the source code directory.
 # (including your code, compiled files, serialized models, everything...)


### PR DESCRIPTION
caching downloaded packages in the container doesn't make sense, they will never be re-used. Avoiding that caching reduces the size of the image and therefore speeds up the upload