### PR TITLE
Numerai CLI 0.3.4

### DIFF
--- a/numerai/cli/util/docker.py
+++ b/numerai/cli/util/docker.py
@@ -148,7 +148,7 @@ def build(node_config, verbose):
     build_arg_str += f' --build-arg MODEL_ID={node_config["model_id"]}'
     build_arg_str += f' --build-arg SRC_PATH={path}'
 
-    cmd = f'docker build -t {node_config["docker_repo"]}' \
+    cmd = f'docker build --platform=linux/amd64 -t {node_config["docker_repo"]}' \
           f'{build_arg_str} -f {path}/Dockerfile .'
 
     execute(cmd, verbose)

--- a/numerai/examples/signals-python3/Dockerfile
+++ b/numerai/examples/signals-python3/Dockerfile
@@ -23,7 +23,7 @@ ENV SRC_PATH=$SRC_PATH
 # The `ADD [source] [destination]` command will take a file from the source directory on your computer
 # and copy it over to the destination directory in the Docker container.
 ADD $SRC_PATH/requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --no-cache-dir
 
 # Now, add everything in the source code directory.
 # (including your code, compiled files, serialized models, everything...)

--- a/numerai/examples/signals-python3/requirements.txt
+++ b/numerai/examples/signals-python3/requirements.txt
@@ -1,5 +1,5 @@
 numerapi==2.4.5
-numpy==1.20.1
+numpy==1.21.0
 pandas==1.2.0
 python-dateutil==2.8.1
 scikit-learn==0.24.0

--- a/numerai/examples/tournament-python3/Dockerfile
+++ b/numerai/examples/tournament-python3/Dockerfile
@@ -1,5 +1,5 @@
 # Provides us a working Python 3 environment.
-FROM python:3.7
+FROM python:3.9
 
 # These are docker arguments that `numerai node deploy/test` will always pass into docker.
 # They are then set in your environment so that numerapi can access them when uploading submissions.

--- a/numerai/examples/tournament-python3/Dockerfile
+++ b/numerai/examples/tournament-python3/Dockerfile
@@ -23,7 +23,7 @@ ENV SRC_PATH=$SRC_PATH
 # The `ADD [source] [destination]` command will take a file from the source directory on your computer
 # and copy it over to the destination directory in the Docker container.
 ADD $SRC_PATH/requirements.txt .
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt --no-cache-dir
 
 # Now, add everything in the source code directory.
 # (including your code, compiled files, serialized models, everything...)

--- a/numerai/examples/tournament-python3/requirements.txt
+++ b/numerai/examples/tournament-python3/requirements.txt
@@ -1,4 +1,4 @@
-numerapi==2.4.5
-pandas==1.2.0
-scikit-learn==0.24.0
-joblib==1.0.0
+numerapi==2.9.2
+pandas==1.3.3
+scikit-learn==1.0.1
+joblib==1.1.0

--- a/numerai/examples/tournament-python3/train.py
+++ b/numerai/examples/tournament-python3/train.py
@@ -1,6 +1,10 @@
+""" An extra entry point specifically for training. Used when running locally """
+
 import predict
 
 train_data_path, predict_data_path, predict_output_path = predict.download_data()
 
-for model_id, model_type in predict.MODEL_CONFIGS:
-    predict.train(train_data_path, model_id, model_type, force_training=True)
+model_id = predict.MODEL_ID
+model_type = predict.MODEL
+
+predict.train(train_data_path, model_id, model_type, force_training=True)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='numerai-cli',
-    version='0.3.4.dev00',
+    version='0.3.4.dev01',
     description='A library for deploying Numer.ai Prediction Nodes.',
     url='https://github.com/numerai/numerai-cli',
     author='Numer.ai',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='numerai-cli',
-    version='0.3.3',
+    version='0.3.4.dev00',
     description='A library for deploying Numer.ai Prediction Nodes.',
     url='https://github.com/numerai/numerai-cli',
     author='Numer.ai',


### PR DESCRIPTION
# Changelog
- Improve formatting/docs to adhere to basic pylint conventions
- Use `--no-cache-dir` during pip installs to prevent large docker image caches
- Use `--platform linux/amd64` during docker builds to prevent errors (requires [Docker Engine API 1.3.8](https://docs.docker.com/engine/api/v1.38/) or higher)
- Upgrade numpy from 1.20 -> 1.21 in signals example script
- Upgrade all package versions in tournament example script
- remove `profile = "default"` from -main.tf to prevent issues with awscli