### PR TITLE
Fix Signals Example

### DIFF
--- a/numerai/examples/signals-python3/data.py
+++ b/numerai/examples/signals-python3/data.py
@@ -92,6 +92,7 @@ def generate_rsi_features(full_data, num_days):
     full_data["RSI"] = ticker_groups["price"].transform(
         lambda x: relative_strength_index(x)
     )
+    full_data.dropna(inplace=True)
 
     # group by era (date)
     logging.info('grouping by dates...')
@@ -102,7 +103,6 @@ def generate_rsi_features(full_data, num_days):
     full_data["RSI_quintile"] = date_groups["RSI"].transform(
         lambda group: pd.qcut(group, 5, labels=False, duplicates="drop")
     )
-    full_data.dropna(inplace=True)
 
     feat_quintile_lag, feat_rsi_diff, feat_rsi_diff_abs = get_rsi_feature_names(num_days)
 

--- a/numerai/examples/signals-python3/predict.py
+++ b/numerai/examples/signals-python3/predict.py
@@ -16,7 +16,7 @@ import pandas as pd
 from sklearn.ensemble import GradientBoostingRegressor
 from dateutil.relativedelta import relativedelta, FR
 
-TARGET_NAME = "target"
+TARGET_NAME = "target_4d"
 PREDICTION_NAME = "signal"
 TRAINED_MODEL_PREFIX = './trained_model'
 


### PR DESCRIPTION
The current signals example fails to work because the generation of RSI features needs to first remove NaN entries. Moreover, model training fails because the target name has changed.

This PR fixed the two issues by:
1. Moving the `dropna` command before grouping by dates,
2. Renaming `TARGET_NAME` to `target_4d`