### PR TITLE
Update ubuntu install instructions

### DIFF
--- a/scripts/setup-ubu.sh
+++ b/scripts/setup-ubu.sh
@@ -35,7 +35,7 @@
   echo "If you encounter issues, include this in your support request:"
   lsb_release -a
   uname -a
-  systemctl status docker
+  systemctl status docker --no-pager
   which docker
 } || {
   echo "Setup script failed, please include the following along with the error if you report this:"


### PR DESCRIPTION
The systemctl status docker leaves the user hanging in a less pager. 

By adding `--no-pager` the one line copy paste install script will end/finish cleanly and not look broken.