### PR TITLE
Small update to ECS tasks security group description

### DIFF
--- a/numerai/terraform/aws/network.tf
+++ b/numerai/terraform/aws/network.tf
@@ -33,7 +33,7 @@ resource "aws_route" "internet_access" {
 # Traffic to the ECS Cluster security group
 resource "aws_security_group" "ecs_tasks" {
   name        = "${local.node_prefix}-tasks"
-  description = "allow inbound access from evertone"
+  description = "Allow all outbound"
   vpc_id      = aws_vpc.main.id
 
   egress {


### PR DESCRIPTION
The security group in question here actually allows all outbound traffic, which makes sense since we need to download a bunch of data in this task.

The previous description wasn't correct and said that this security group allowed ingress (inbound) traffic and had a typo.