### PR TITLE
Resolve list deprecation in Terraform >0.12

### DIFF
--- a/numerai/terraform/aws/aws/webhook.tf
+++ b/numerai/terraform/aws/aws/webhook.tf
@@ -123,9 +123,9 @@ resource "aws_apigatewayv2_deployment" "submit" {
   api_id = aws_apigatewayv2_api.submit.id
 
   triggers = {
-    redeployment = sha1(join(",", list(
+    redeployment = sha1(join(",", tolist([
       jsonencode(aws_apigatewayv2_integration.submit),
-      jsonencode(aws_apigatewayv2_route.submit),
+      jsonencode(aws_apigatewayv2_route.submit)]
     )))
   }
 


### PR DESCRIPTION
We missed an issue with the AWS webhook terraform when we updated the terraform image version.

The function `list` has been deprecated in favor of `tolist`. This PR converts `list` in AWS terraform to `tolist` without changing the behavior of this property.